### PR TITLE
Prints text on mobile to indicate that you can swipe between slides

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useDeck } from 'gatsby-theme-mdx-deck'
 import { AnimatePresence, motion } from 'framer-motion'
 
 const variants = {
@@ -13,6 +14,7 @@ const variants = {
 }
 
 export default ({ children }) => {
+  const { index } = useDeck()
   return (
     <main>
       <AnimatePresence>
@@ -29,6 +31,15 @@ export default ({ children }) => {
           </motion.div>
         ))}
       </AnimatePresence>
+      {index > 0 &&
+        <div className="mobile-only" style={{ color: '#bfbfbf', fontSize: 28, marginTop: 96, textAlign: 'center' }}>
+          <p>
+            <span>{'\u2190'}&nbsp;&nbsp;</span>
+            <em>Swipe</em>
+            <span>&nbsp;&nbsp;{'\u2192'}</span>
+          </p>
+        </div>
+      }
     </main>
   )
 }

--- a/src/components/Provider.js
+++ b/src/components/Provider.js
@@ -14,6 +14,9 @@ const mediaQueries = css`
   #gatsby-focus-wrapper > div > div > div {
     height: auto !important;
   }
+  .mobile-only {
+    display: none;
+  }
   p a {
     &::after {
       background: rgba(0, 0, 0, 0.1);
@@ -49,6 +52,9 @@ const mediaQueries = css`
     }
     .hide-on-mobile {
       display: none !important;
+    }
+    .mobile-only {
+      display: block !important;
     }
     main {
       margin-left: 24px;


### PR DESCRIPTION
This pull request adds a media query to print text at the bottom of each slide to let the user know that you can use the swipe left/right gesture to advance slides.